### PR TITLE
Update `composer create-project` options in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is a simple skeleton project for Slim 3 that includes Twig, Flash messages 
 
 ## Create your project:
 
-    $ composer create-project -n -s dev akrabat/slim3-skeleton my-app
+    $ composer create-project --no-interaction --stability=dev akrabat/slim3-skeleton my-app
 
 ### Run it:
 


### PR DESCRIPTION
I swapped the short options for the long options for clarity. I feel
like it's a little nicer because, especially for people new to Composer,
it's immediately obvious what options are being used with the `create-project`
command.
