### PR TITLE
Fixing incorrect request/response FQNS

### DIFF
--- a/app/src/Action/HomeAction.php
+++ b/app/src/Action/HomeAction.php
@@ -3,8 +3,8 @@ namespace App\Action;
 
 use Slim\Views\Twig;
 use Psr\Log\LoggerInterface;
-use Psr\Http\Message\ServerRequestInterface as Request;
-use Psr\Http\Message\ResponseInterface as Response;
+use Slim\Http\Request;
+use Slim\Http\Response;
 
 final class HomeAction
 {


### PR DESCRIPTION
By default (and in the case of this skeleton app) Slim returns request
and response objects that have additional functionality over PSR-7.
Although they are PSR-7 compliant, they have these additional methods
which is useful. If you are using these methods then your IDE will
probably highlight them as an error due to the PSR-7 type-hinting.

Refs #34 
